### PR TITLE
Mistake in artnet.cpp

### DIFF
--- a/Artnet.cpp
+++ b/Artnet.cpp
@@ -121,7 +121,7 @@ uint16_t Artnet::read()
 
         uint8_t swin[4]  = {0x01,0x02,0x03,0x04};
         uint8_t swout[4] = {0x01,0x02,0x03,0x04};
-        for(uint8_t i = 0; i <= 4; i++)
+        for(uint8_t i = 0; i < 4; i++)
         {
             ArtPollReply.swout[i] = swout[i];
             ArtPollReply.swin[i] = swin[i];


### PR DESCRIPTION
I found a little mistake in artnet.cpp. It has an important impact: By writing one byte too much in the for-loop the first byte of swout is overwritten randomly. As a result only some polls work and the whole communication gets unstable.
